### PR TITLE
Handle compressed empty files correctly

### DIFF
--- a/source/archive.d
+++ b/source/archive.d
@@ -44,6 +44,10 @@ private string readArchiveData (archive *ar, string name = null)
     char[BUFFER_SIZE] buff;
 
     ret = archive_read_next_header (ar, &ae);
+
+    if (ret == ARCHIVE_EOF)
+        return data;
+
     if (ret != ARCHIVE_OK) {
         if (name is null)
             throw new Exception (format ("Unable to read header of compressed data."));
@@ -77,6 +81,7 @@ string decompressFile (string fname)
     scope(exit) archive_read_free (ar);
 
     archive_read_support_format_raw (ar);
+    archive_read_support_format_empty (ar);
     archive_read_support_filter_all (ar);
 
     ret = archive_read_open_filename (ar, toStringz (fname), 16384);
@@ -94,6 +99,7 @@ string decompressData (ubyte[] data)
     scope(exit) archive_read_free (ar);
 
     archive_read_support_filter_all (ar);
+    archive_read_support_format_empty (ar);
     archive_read_support_format_raw (ar);
 
     auto dSize = ubyte.sizeof * data.length;
@@ -465,4 +471,17 @@ public:
         }
     }
 
+}
+
+unittest
+{
+    writeln ("TEST: ", "Compressed empty file");
+
+    ubyte emptyGz [] = [
+       0x1f, 0x8b, 0x08, 0x08, 0x00, 0x00, 0x00, 0x00,
+       0x00, 0x03, 0x65, 0x6d, 0x70, 0x74, 0x79, 0x00,
+       0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+       0x00, 0x00,
+    ];
+    assert (decompressData (emptyGz) == "");
 }

--- a/source/backends/debian/tagfile.d
+++ b/source/backends/debian/tagfile.d
@@ -46,12 +46,7 @@ public:
         try {
             data = decompressFile (fname);
         } catch (Exception e) {
-            // libarchive fails to detect GZip-compressed zero-byte documents proprly and emits an error.
-            // We don't want this to be a permanent failure, so we ignore errors in that particular case.
-            if (fname.endsWith (".gz"))
-                logWarning (e.msg);
-            else
-                throw e;
+            throw e;
         }
 
         content = splitLines (data);

--- a/source/bindings/libarchive.d
+++ b/source/bindings/libarchive.d
@@ -47,6 +47,7 @@ int archive_read_support_filter_gzip (archive*);
 int archive_read_support_filter_lzma (archive*);
 
 int archive_read_support_format_raw (archive*);
+int archive_read_support_format_empty (archive*);
 int archive_read_support_format_all (archive*);
 int archive_read_support_format_ar (archive*);
 int archive_read_support_format_gnutar (archive*);


### PR DESCRIPTION
This reverts some of 63584a0 and fixes #1 

See [libarchive #706](https://github.com/libarchive/libarchive/issues/706#issuecomment-219239144) for an explanation of why this is necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ximion/appstream-generator/8)
<!-- Reviewable:end -->
