### PR TITLE
Topic/repeatable

### DIFF
--- a/data/templates/default/issues_index.html
+++ b/data/templates/default/issues_index.html
@@ -32,8 +32,4 @@
       {{/summaries}}
 {{/partial}}
 
-{{#partial}}{ float_right }
-<small>Last updated on: {{time}}</small>
-{{/partial}}
-
 {{> base}}

--- a/data/templates/default/issues_page.html
+++ b/data/templates/default/issues_page.html
@@ -1,9 +1,5 @@
 {{#partial}}{title}Issues for {{package_name}} in {{suite}}/{{section}}{{/partial}}
 
-{{#partial}}{ float_right }
-<small>Last updated on: {{time}}</small>
-{{/partial}}
-
 {{#partial}}{ header_content }
 <span style="font-size:18px;"><a href="index.html" style="color: #000000;">⇦ |</a></span>
 

--- a/data/templates/default/metainfo_index.html
+++ b/data/templates/default/metainfo_index.html
@@ -30,8 +30,4 @@
 
 {{/partial}}
 
-{{#partial}}{ float_right }
-<small>Last updated on: {{time}}</small>
-{{/partial}}
-
 {{> base}}

--- a/data/templates/default/metainfo_page.html
+++ b/data/templates/default/metainfo_page.html
@@ -1,9 +1,5 @@
 {{#partial}}{title}{{package_name}} in {{suite}}/{{section}}{{/partial}}
 
-{{#partial}}{ float_right }
-<small>Last updated on: {{time}}</small>
-{{/partial}}
-
 {{#partial}}{ head_extra }
 <link rel="stylesheet" href="{{root_url}}/static/css/highlight.css">
 <script src="{{root_url}}/static/js/highlight/highlight.pack.js"></script>

--- a/data/templates/default/section_overview.html
+++ b/data/templates/default/section_overview.html
@@ -164,8 +164,4 @@
 
 {{/partial}}
 
-{{#partial}}{ float_right }
-<small>Last updated on: {{time}}</small>
-{{/partial}}
-
 {{> base}}

--- a/data/templates/default/sections_index.html
+++ b/data/templates/default/sections_index.html
@@ -123,8 +123,4 @@
 
 {{/partial}}
 
-{{#partial}}{ float_right }
-<small>Last updated on: {{time}}</small>
-{{/partial}}
-
 {{> base}}

--- a/source/engine.d
+++ b/source/engine.d
@@ -228,7 +228,7 @@ public:
         if (withIconTar) {
             foreach (size; iconTarSizes) {
                 iconTar[size] = new ArchiveCompressor (ArchiveType.GZIP);
-                iconTar[size].open (buildPath (dataExportDir, format ("icons-%sx%s.tar.gz", size, size)));
+                iconTar[size].open (buildPath (dataExportDir, format ("icons-%sx%s.tar", size, size)));
             }
         }
 

--- a/source/engine.d
+++ b/source/engine.d
@@ -233,7 +233,7 @@ public:
         }
 
         // collect metadata, icons and hints for the given packages
-        foreach (ref pkg; parallel (pkgs, 100)) {
+        foreach (ref pkg; pkgs) {
             auto pkid = Package.getId (pkg);
             auto gcids = dcache.getGCIDsForPackage (pkid);
             if (gcids !is null) {


### PR DESCRIPTION
These are some changes I've made for use with my own repo and workflow, but you may find some or all of them useful.

I run the generator on all suites one per day, from a cronjob. However, most days the repo hasn't changed, since this is a small, 3rd-party repo. I then copy the new metadata into the repo. However, `asgen` produces different output every time, even when there have been no changes to the repo, This results in a lot of churn when the master copy of the repo is pushed to the mirror that people actually have access to, which in turn produces unnecessary emails to my inbox.

I found that the churn was occurring in three areas:

1. All gzipped files
2. "Last updated" timestamps in the html
3. Non-deterministic ordering of the icons archives

Each of these commits fixes one of those.

I copy the data from workspace to repo using `rsync -rlHc`. That changes a destination file only if the source file has a different checksum. However, it doesn't copy across the modification time like `-a` does, so a destination file with the same checksum doesn't have its modification date changed, but files with a different checksum have their modification time set to the time of the copy. I can then use `find` to see if there are any files in the `dep11` subdirectory that are newer than the `Release` file, and if so the suite needs to be reexported (in my case, with `reprepo export SUITE`) and a mirror push initiated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ximion/appstream-generator/9)
<!-- Reviewable:end -->
