### PR TITLE
run bower with allow root to be able to make js as root

### DIFF
--- a/contrib/setup/build_js.sh
+++ b/contrib/setup/build_js.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-bower install jquery jquery-flot highlightjs
+bower --allow-root install jquery jquery-flot highlightjs
 
 JS_TARGET=../../data/templates/default/static/js
 


### PR DESCRIPTION
in particular I am running the generator inside linux containers as
in-container root, so bower refusing to bow on account of being run as root
is kind of silly