### PR TITLE
Download file to memory fix

### DIFF
--- a/source/backends/debian/debpkgindex.d
+++ b/source/backends/debian/debpkgindex.d
@@ -94,6 +94,8 @@ public:
     {
         immutable langs = findTranslations (suite, section);
 
+        logDebug ("Found translations for: %s", langs.join(", "));
+
         foreach (const ref lang; langs) {
             string fname;
 
@@ -117,7 +119,6 @@ public:
             auto tagf = new TagFile ();
             tagf.open (fname);
 
-            logDebug ("Opened: %s", fname);
             do {
                 auto pkgname = tagf.readField ("Package");
                 auto rawDesc  = tagf.readField ("Description-%s".format (lang));

--- a/source/utils.d
+++ b/source/utils.d
@@ -411,21 +411,21 @@ string[] getFileContents (const string path, const uint retryCount = 5) @trusted
 
     size_t sz = 0;
 
-    auto f = open_memstream (&ptr, &sz);
-    scope (exit) fclose (f);
-
-    auto file = File.wrapFile (f);
-
     if (path.isRemote) {
-        download (path, file, retryCount);
+        {
+            auto f = open_memstream (&ptr, &sz);
+            scope (exit) fclose (f);
+            auto file = File.wrapFile (f);
+            download (path, file, retryCount);
+        }
+
+        return to!string (ptr.fromStringz).splitLines;
     } else {
         if (!std.file.exists (path))
             throw new Exception ("No such file '%s'", path);
 
         return std.file.readText (path).splitLines;
     }
-
-    return to!string (ptr.fromStringz).splitLines;
 }
 
 /**


### PR DESCRIPTION
I was using `make fast`, and noticed that `getFileContents` wasn't working. I suspect that at higher optimisation levels the `scope (exit) fclose (f)` is happening earlier. It needs to happen before we read from the pointer (see the full commit message).

(Also squash some overly verbose debug logging, which isn't really related to this bug, but here we are.)