### PR TITLE
Make downloading more robust

### DIFF
--- a/source/backends/debian/debpkg.d
+++ b/source/backends/debian/debpkg.d
@@ -62,7 +62,9 @@ public:
     @property string filename () const {
         if (debFname.isRemote) {
             immutable path = buildNormalizedPath (tmpDir, debFname.baseName);
-            downloadFile (debFname, path);
+            synchronized (this) {
+                downloadFile (debFname, path);
+            }
             return path;
         }
         return debFname;

--- a/source/backends/debian/debpkgindex.d
+++ b/source/backends/debian/debpkgindex.d
@@ -74,15 +74,17 @@ public:
         bool[string] ret;
 
         try {
-            const inReleaseContents = getFileContents (inRelease);
+            synchronized (this) {
+                const inReleaseContents = getFileContents (inRelease);
 
-            foreach (const ref entry; inReleaseContents) {
-                auto match = entry.matchFirst (translationregex);
+                foreach (const ref entry; inReleaseContents) {
+                    auto match = entry.matchFirst (translationregex);
 
-                if (match.empty)
-                    continue;
+                    if (match.empty)
+                        continue;
 
-                ret[match[1]] = true;
+                    ret[match[1]] = true;
+                }
             }
         } catch (Exception ex) {
             logWarning ("Could not get %s, will assume 'en' is available.", inRelease);
@@ -112,7 +114,9 @@ public:
                                             "Translation-%s.%s".format(lang, "%s"));
 
             try {
-                fname = downloadIfNecessary (rootDir, tmpDir, fullPath);
+                synchronized (this) {
+                    fname = downloadIfNecessary (rootDir, tmpDir, fullPath);
+                }
             } catch (Exception ex) {
                 logDebug ("No translations for %s in %s/%s", lang, suite, section);
                 continue;
@@ -175,7 +179,9 @@ public:
     {
         immutable path = buildPath ("dists", suite, section, "binary-%s".format (arch));
 
-        return downloadIfNecessary (rootDir, tmpDir, buildPath (path, "Packages.%s"));
+        synchronized (this) {
+            return downloadIfNecessary (rootDir, tmpDir, buildPath (path, "Packages.%s"));
+        }
     }
 
     protected DebPackage newPackage (string name, string ver, string arch)

--- a/source/utils.d
+++ b/source/utils.d
@@ -352,7 +352,7 @@ in { assert (url.isRemote); }
 body
 {
     import core.time;
-    import std.net.curl : CurlTimeoutException, HTTP, FTP;
+    import std.net.curl : CurlException, HTTP, FTP;
 
     size_t onReceiveCb (File f, ubyte[] data)
     {
@@ -377,7 +377,7 @@ body
             downloader.perform();
         }
         logDebug ("Downloaded %s", url);
-    } catch (CurlTimeoutException e) {
+    } catch (CurlException e) {
         if (retryCount > 0) {
             logDebug ("Failed to download %s, will retry %d more %s",
                       url,


### PR DESCRIPTION
Two things

- We should catch more than just timeout errors
- There's some thread unsafety when multiple threads try to download the same file - we need to synchronise this.

I'm not sure if the package index is actually accessed by multiple threads - is this bit needed?