### PR TITLE
engine: Don't clean packages in base suites

### DIFF
--- a/src/asgen/engine.d
+++ b/src/asgen/engine.d
@@ -591,6 +591,8 @@ public:
             foreach (ref section; suite.sections) {
                 foreach (ref arch; parallel (suite.architectures)) {
                     auto pkgs = pkgIndex.packagesFor (suite.name, section, arch);
+                    if (!suite.baseSuite.empty)
+                        pkgs ~= pkgIndex.packagesFor (suite.baseSuite, section, arch);
                     synchronized (this) {
                         foreach (ref pkg; pkgs) {
                             pkgSet[pkg.id] = true;


### PR DESCRIPTION
I'm trying a configuration with `xenial-updates` (etc) but not `xenial` and was like "why is it processing all of xenial every time?"

Turns out that, because I run clean each time, it was cleaning all of `xenial` :(. I think that clean should keep base suites around too.