### PR TITLE
hints: icon-not-found: Explain the symlink problem for Debian & Ubuntu

### DIFF
--- a/data/asgen-hints.json
+++ b/data/asgen-hints.json
@@ -33,6 +33,7 @@
             "  <li>The icon is not present in the archive.</li>",
             "  <li>The icon is in a wrong directory.</li>",
             "  <li>The icon is not available in a suitable size (at least 64x64px)</li>",
+            "  <li>On Debian and Ubuntu, the icon is a symlink. The generator cannot read symlinks on these distributions - make the icon a real file.</li>",
             "</ul>",
             "To make the icon easier to find, place it in <code>/usr/share/icons/hicolor/&lt;size&gt;/apps</code> and ensure the <code>Icon=</code> value",
             "of the .desktop file is set correctly."


### PR DESCRIPTION
I was just diffing the `Components` between as-dep11 and asgen, and there are actually quite a few of these. I think we should at least explain the problem in the output.

If it's possible to only output this on Debian & Ubuntu then we should do that, but I don't think it is so it's okay to have it for everyone IMO.

Feel free to edit the message.