### PR TITLE
Generate type=codec metadata for gstreamer packages

### DIFF
--- a/docs/asgen-config.md
+++ b/docs/asgen-config.md
@@ -83,3 +83,4 @@ optimizePNGSize | Use `optipng` to reduce the size of PNG images. Optipng needs 
 metadataTimestamps | Write timestamps into generated metadata files. *Default: `ON`*
 immutableSuites | Allow suites to be marked as immutable. This is useful for distributions with fixed releases, but not for rolling release distributions or continuously updated repositories. *Default: `ON`*
 processFonts | Include font metadata and render fonts. *Default: `ON`*
+processGStreamer | Synthesise `type=codec` metadata from available GStreamer packages. Requires support in the backend, currently only implemented for Debian. *Default: `ON`*

--- a/src/asgen/backends/debian/debpkg.d
+++ b/src/asgen/backends/debian/debpkg.d
@@ -41,6 +41,8 @@ private:
     string pkgarch;
     string pkgmaintainer;
     string[string] desc;
+    string[string] summ;
+    GStreamer gstreamer;
 
     bool contentsRead;
     string[] contentsL;
@@ -56,7 +58,11 @@ public:
     final @property override string ver () const { return pkgver; }
     final @property override string arch () const { return pkgarch; }
 
+    final @property override GStreamer gst () { return gstreamer; }
+    final @property void gst (GStreamer gst) { gstreamer = gst; }
+
     final @property override const(string[string]) description () const { return desc; }
+    final @property override const(string[string]) summary () const { return summ; }
 
     override final
     @property string filename () const {
@@ -97,6 +103,11 @@ public:
     final void setDescription (string text, string locale)
     {
         desc[locale] = text;
+    }
+
+    final void setSummary (string text, string locale)
+    {
+        summ[locale] = text;
     }
 
     private auto openPayloadArchive ()

--- a/src/asgen/backends/debian/debpkgindex.d
+++ b/src/asgen/backends/debian/debpkgindex.d
@@ -141,6 +141,12 @@ public:
                 if (split.length < 2)
                     continue;
 
+
+                if (lang == "en")
+                    (*pkgP).setSummary (split[0], "C");
+
+                (*pkgP).setSummary (split[0], lang);
+
                 // NOTE: .remove() removes the element, but does not alter the
                 // length of the array. Bug?  (this is why we slice the array
                 // here)
@@ -203,6 +209,9 @@ public:
 
         DebPackage[string] pkgs;
         do {
+            import std.algorithm : map;
+            import std.array : array;
+
             auto name  = tagf.readField ("Package");
             auto ver   = tagf.readField ("Version");
             auto fname = tagf.readField ("Filename");
@@ -212,6 +221,28 @@ public:
             auto pkg = newPackage (name, ver, arch);
             pkg.filename = buildPath (rootDir, fname);
             pkg.maintainer = tagf.readField ("Maintainer");
+
+            immutable decoders = tagf.readField("Gstreamer-Decoders")
+                .split(";")
+                .map!strip.array;
+
+            immutable encoders = tagf.readField("Gstreamer-Encoders")
+                .split(";")
+                .map!strip.array;
+
+            immutable elements = tagf.readField("Gstreamer-Elements")
+                .split(";")
+                .map!strip.array;
+
+            immutable uri_sinks = tagf.readField("Gstreamer-Uri-Sinks")
+                .split(";")
+                .map!strip.array;
+
+            immutable uri_sources = tagf.readField("Gstreamer-Uri-Sources")
+                .split(";")
+                .map!strip.array;
+
+            pkg.gst = new GStreamer(decoders, encoders, elements, uri_sinks, uri_sources);
 
             if (!pkg.isValid ()) {
                 logWarning ("Found invalid package (%s)! Skipping it.", pkg.toString ());

--- a/src/asgen/backends/interfaces.d
+++ b/src/asgen/backends/interfaces.d
@@ -26,6 +26,38 @@ import std.string;
 import std.container;
 public import asgen.datastore;
 
+class GStreamer
+{
+    immutable string[] decoders;
+    immutable string[] encoders;
+    immutable string[] elements;
+    immutable string[] uri_sinks;
+    immutable string[] uri_sources;
+
+    @property @safe pure bool isNotEmpty() {
+        return !(decoders.empty &&
+                 encoders.empty &&
+                 elements.empty &&
+                 uri_sinks.empty &&
+                 uri_sources.empty);
+    }
+
+    this () {
+        decoders = encoders = elements = uri_sinks = uri_sources = [];
+    }
+
+    this (immutable string[] decoders,
+          immutable string[] encoders,
+          immutable string[] elements,
+          immutable string[] uri_sinks,
+          immutable string[] uri_sources) {
+        this.decoders = decoders;
+        this.encoders = encoders;
+        this.elements = elements;
+        this.uri_sinks = uri_sinks;
+        this.uri_sources = uri_sources;
+    }
+}
 
 /**
  * Represents a distribution package in the generator.
@@ -44,6 +76,14 @@ abstract class Package
      * E.g.: ["en": "A description.", "de": "Eine Beschreibung"]
      */
     @property const(string[string]) description () const;
+
+    /**
+     * A associative array containing package summaries.
+     * Key is the language (or locale), value the summary.
+     *
+     * E.g.: ["en": "foo the bar"]
+     */
+    @property const(string[string]) summary () const { return (string[string]).init; };
 
     /**
      * Filename of the package. This string is only used for
@@ -67,6 +107,8 @@ abstract class Package
      * no longer request any file data from this package.
      */
     abstract void close () {};
+
+    @property GStreamer gst () { return new GStreamer(); }
 
     /**
      * Retrieve backend-specific translations.

--- a/src/asgen/config.d
+++ b/src/asgen/config.d
@@ -81,7 +81,8 @@ enum GeneratorFeature
     OPTIPNG             = 1 << 4,
     METADATA_TIMESTAMPS = 1 << 5,
     IMMUTABLE_SUITES    = 1 << 6,
-    PROCESS_FONTS       = 1 << 6
+    PROCESS_FONTS       = 1 << 7,
+    PROCESS_GSTREAMER   = 1 << 8,
 }
 
 final class Config
@@ -377,6 +378,7 @@ public:
         setFeature (GeneratorFeature.METADATA_TIMESTAMPS, true);
         setFeature (GeneratorFeature.IMMUTABLE_SUITES, true);
         setFeature (GeneratorFeature.PROCESS_FONTS, true);
+        setFeature (GeneratorFeature.PROCESS_GSTREAMER, true);
 
         // apply vendor feature settings
         if ("Features" in root.object) {
@@ -406,6 +408,9 @@ public:
                             break;
                     case "processFonts":
                             setFeature (GeneratorFeature.PROCESS_FONTS, featuresObj[featureId].type == JSON_TYPE.TRUE);
+                            break;
+                    case "processGStreamer":
+                            setFeature (GeneratorFeature.PROCESS_GSTREAMER, featuresObj[featureId].type == JSON_TYPE.TRUE);
                             break;
                     default:
                         break;

--- a/src/asgen/engine.d
+++ b/src/asgen/engine.d
@@ -155,8 +155,9 @@ public:
      **/
     private bool seedContentsData (Suite suite, string section, string arch)
     {
-        bool packageInteresting (const string[] contents)
+        bool packageInteresting (Package pkg)
         {
+            auto contents = pkg.contents;
             foreach (ref c; contents) {
                 if (c.startsWith ("/usr/share/applications/"))
                     return true;
@@ -166,7 +167,7 @@ public:
                     return true;
             }
 
-            return false;
+            return pkg.gst.isNotEmpty;
         }
 
         // check if the index has changed data, skip the update if there's nothing new
@@ -223,7 +224,7 @@ public:
             }
 
             // check if we can already mark this package as ignored, and print some log messages
-            if (!packageInteresting (contents)) {
+            if (!packageInteresting (pkg)) {
                 dstore.setPackageIgnore (pkid);
                 logInfo ("Scanned %s, no interesting files found.", pkid);
                 // we won't use this anymore

--- a/src/asgen/extractor.d
+++ b/src/asgen/extractor.d
@@ -19,6 +19,7 @@
 
 module asgen.extractor;
 
+import std.array : appender;
 import std.stdio;
 import std.string;
 import std.path : baseName;
@@ -198,6 +199,24 @@ public:
             auto cpt = parseDesktopFile (gres, dfname, ddata, false);
             if (cpt !is null)
                 gres.updateComponentGCID (cpt, ddata);
+        }
+
+        if (pkg.gst.isNotEmpty) {
+            auto data = appender!string;
+            auto cpt = new Component ();
+
+            data.reserve(512);
+
+            cpt.setId (pkg.name);
+            cpt.setKind (ComponentKind.CODEC);
+            cpt.setName ("GStreamer Multimedia Codecs", "C");
+            foreach (ref lang, ref desc; pkg.summary) {
+                cpt.setSummary (desc, lang);
+                data ~= desc;
+            }
+
+            gres.addComponent (cpt);
+            gres.updateComponentGCID (cpt, data.data);
         }
 
         auto hasFontComponent = false;

--- a/src/asgen/extractor.d
+++ b/src/asgen/extractor.d
@@ -201,7 +201,7 @@ public:
                 gres.updateComponentGCID (cpt, ddata);
         }
 
-        if (pkg.gst.isNotEmpty) {
+        if (conf.featureEnabled (GeneratorFeature.PROCESS_GSTREAMER) && pkg.gst.isNotEmpty) {
             auto data = appender!string;
             auto cpt = new Component ();
 


### PR DESCRIPTION
OK, here we go.

See https://bugzilla.gnome.org/show_bug.cgi?id=782795

The GStreamer codec listings in GS look quite bad currently, because there's no AS metadata for them. Upstream didn't want to consider this yet (AFAIK). `type=codec` isn't specced properly in AS and we'd want to fix that before proposing anything up there. Fedora ships downstream metadata in their packages. For us in Debian and Ubuntu we have the ability to generate this information because our package indices specify what's in them (`Gstreamer-*`).

I'll add some questions inline, but I hope the general idea is OK. To test: remove all the `gstreamer1.0-plugins-*` and `gstreamer1.0-libav` packages from your system, open an audio file in totem, launch GS when you're prompted to, and look at the list of packages offered up for installation. With this commit, you should get descriptions at least - and GS 3.26 should add icons to these too.