### PR TITLE
use file.exists to check file existance

### DIFF
--- a/src/asgen/zarchive.d
+++ b/src/asgen/zarchive.d
@@ -459,7 +459,7 @@ void compressAndSave (ubyte[] data, const string fname, ArchiveType atype)
     archive_write_close (ar);
 
     // delete old file if it exists
-    if (fname.isFile)
+    if (std.file.exists (fname))
         fname.remove ();
     // rename temporary file to actual file
     std.file.rename (tmpFname, fname); // we need to use std.file explicitly, because otherwise core.stdc gets used


### PR DESCRIPTION
isFile is only useful to distinguish between files and folders, and will throw an exception if the file doesn't exist. In 0.6.6 it always aborts with an exception unless the archive is already present.