### PR TITLE
config: allow overriding export dir via --exportDir

### DIFF
--- a/src/app.d
+++ b/src/app.d
@@ -53,7 +53,8 @@ Application Options:
   --verbose        Show extra debugging information.
   --force          Force action.
   -w|--workspace   Define the workspace location.
-  -c|--config      Use the given configuration file.";
+  -c|--config      Use the given configuration file.
+  -e|--exportDir   Directory to export data to.";
 
 version (unittest) {
 void main () {}
@@ -95,6 +96,7 @@ void main(string[] args)
     bool showVersion;
     bool forceAction;
     string wdir;
+    string edir;
     string configFname;
 
     // parse command-line options
@@ -105,7 +107,8 @@ void main(string[] args)
             "version", &showVersion,
             "force", &forceAction,
             "workspace|w", &wdir,
-            "config|c", &configFname);
+            "config|c", &configFname,
+            "exportDir|e", &edir);
     } catch (Exception e) {
         writeln ("Unable to parse parameters: ", e.msg);
         exit (1);
@@ -140,7 +143,7 @@ void main(string[] args)
     }
 
     try {
-        conf.loadFromFile (configFname, wdir);
+        conf.loadFromFile (configFname, wdir, edir);
     } catch (Exception e) {
         writefln ("Unable to load configuration: %s", e.msg);
         exit (4);

--- a/src/asgen/config.d
+++ b/src/asgen/config.d
@@ -265,7 +265,7 @@ public:
         return null;
     }
 
-    void loadFromFile (string fname, string enforcedWorkspaceDir = null)
+    void loadFromFile (string fname, string enforcedWorkspaceDir = null, string enforcedExportDir = null)
     {
         import bindings.gdkpixbuf : gdkPixbufGetFormatNames;
 
@@ -306,6 +306,11 @@ public:
 
         // set the default export directory locations, allow people to override them in the config
         exportDir      = buildPath (workspaceDir, "export");
+
+        // allow overriding the export  location
+        if (!enforcedExportDir.empty)
+            exportDir = enforcedExportDir;
+
         mediaExportDir = buildPath (exportDir, "media");
         dataExportDir  = buildPath (exportDir, "data");
         hintsExportDir = buildPath (exportDir, "hints");


### PR DESCRIPTION
This is useful for e.g. exporting to a versioned
(by date) dir.

fixes #81 