### PR TITLE
Also remove the handled desktop file with a suffix

### DIFF
--- a/src/asgen/extractor.d
+++ b/src/asgen/extractor.d
@@ -239,8 +239,7 @@ public:
                     gres.updateComponentGcid (cpt, deDataBytes);
 
                     // drop the .desktop file from the list, it has been handled
-                    desktopFiles.remove (cid);
-                    desktopFiles.remove (cid ~ ".desktop");
+                    desktopFiles.remove (dfname);
                 }
             }
 

--- a/src/asgen/extractor.d
+++ b/src/asgen/extractor.d
@@ -240,6 +240,7 @@ public:
 
                     // drop the .desktop file from the list, it has been handled
                     desktopFiles.remove (cid);
+                    desktopFiles.remove (cid ~ ".desktop");
                 }
             }
 


### PR DESCRIPTION
Otherwise it processed twice, and overrides data from metainfo file.

Fixes #88