### PR TITLE
config: Move setUseOptipng call after we determine if optipng is available

### DIFF
--- a/src/asgen/config.d
+++ b/src/asgen/config.d
@@ -611,7 +611,6 @@ public:
         }
 
         // check if we need to disable features because some prerequisites are not met
-        Globals.setUseOptipng (feature.optipng);
         if (feature.optipng) {
             if (optipngBinary.empty) {
                 feature.optipng = false;
@@ -620,6 +619,7 @@ public:
                 logDebug ("Using `optipng`: %s", optipngBinary);
             }
         }
+        Globals.setUseOptipng (feature.optipng);
         if (feature.screenshotVideos) {
             if (ffprobeBinary.empty) {
                 feature.screenshotVideos = false;


### PR DESCRIPTION
Currently we tell AsCompose to use optipng just based on the value of
the feature flag. AsCompose will respect what we tell it without further
checking. If optipng is in fact not available then we'll crash later on
when we first try to use it.

Fix this by setting the flag *after* we check if optipng is installed.