### PR TITLE
snapcraft: stage libzstd1

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -152,6 +152,7 @@ parts:
       - libxdmcp6
       - libxext6
       - libxrender1
+      - libzstd1
       - locales
       - locales-all
       - shared-mime-info


### PR DESCRIPTION
appstream-generator depends on libarchive, which depends on libzstd1,
however it appears to not be staged into the snap. This results in
libzstd1 being used from the host system which may or may not be
compatible with the snap staged libarchive library. In order to
produce consistent results stage libzstd1 into the snap as well.