### PR TITLE
ci: Add Fedora to the CI environment

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -3,6 +3,25 @@ name: Build Test
 on: [push, pull_request]
 
 jobs:
+  build-fedora-rawhide:
+    name: Fedora Rawhide
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dc: [ldc, gdc]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Create Build Environment
+      run: cd tests/ci/ && podman build -t asgen -f ./Dockerfile-fedora-rawhide .
+
+    - name: Build & Test
+      continue-on-error: ${{ matrix.dc == 'gdc' }}
+      run: podman run -a stdout -a stderr -e DC=${{ matrix.dc }} -v `pwd`:/build asgen
+           ./tests/ci/build-and-test.sh
+
+
   build-debian-testing:
     name: Debian Testing
     runs-on: ubuntu-latest

--- a/tests/ci/Dockerfile-fedora-rawhide
+++ b/tests/ci/Dockerfile-fedora-rawhide
@@ -1,0 +1,18 @@
+#
+# Docker file for AppStream Generator CI tests
+#
+FROM registry.fedoraproject.org/fedora:rawhide
+
+# prepare
+RUN mkdir -p /build/ci/
+
+# install build dependencies
+COPY install-deps-rpm.sh /build/ci/
+RUN chmod +x /build/ci/install-deps-rpm.sh && /build/ci/install-deps-rpm.sh
+
+# install 3rd-party stuff
+COPY ci-install-extern.sh /build/ci/
+RUN chmod +x /build/ci/ci-install-extern.sh && /build/ci/ci-install-extern.sh
+
+# finish
+WORKDIR /build

--- a/tests/ci/install-deps-rpm.sh
+++ b/tests/ci/install-deps-rpm.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+#
+# Install AppStream Generator build dependencies
+#
+set -e
+set -x
+
+# Install rpmfusion repositories
+dnf --assumeyes --quiet install https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm --eval %fedora).noarch.rpm
+
+# update caches
+dnf makecache
+
+# install dependencies
+dnf --assumeyes --quiet --setopt=install_weak_deps=False install \
+    curl \
+    gdb \
+    gcc \
+    gcc-c++ \
+    gcc-gdc \
+    git-core \
+    meson \
+    ffmpeg \
+    gettext \
+    gir-to-d \
+    gnupg \
+    gperf \
+    docbook-dtds \
+    docbook-style-xsl \
+    ldc \
+    libasan \
+    libstemmer-devel \
+    libubsan \
+    'pkgconfig(cairo)' \
+    'pkgconfig(freetype2)' \
+    'pkgconfig(fontconfig)' \
+    'pkgconfig(gdk-pixbuf-2.0)' \
+    'pkgconfig(glib-2.0)' \
+    'pkgconfig(gobject-2.0)' \
+    'pkgconfig(gio-2.0)' \
+    'pkgconfig(glibd-2.0)' \
+    'pkgconfig(gobject-introspection-1.0)' \
+    'pkgconfig(libarchive)' \
+    'pkgconfig(libcurl)' \
+    'pkgconfig(libsoup-2.4)' \
+    'pkgconfig(librsvg-2.0)' \
+    'pkgconfig(libxml-2.0)' \
+    'pkgconfig(lmdb)' \
+    'pkgconfig(packagekit-glib2)' \
+    'pkgconfig(pango)' \
+    'pkgconfig(protobuf-lite)' \
+    'pkgconfig(Qt5Core)' \
+    qt5-linguist \
+    'pkgconfig(yaml-0.1)' \
+    sed \
+    vala \
+    xmlto \
+    /usr/bin/node \
+    /usr/bin/xsltproc \
+    /usr/bin/yarnpkg


### PR DESCRIPTION
As Fedora ships updated D language and GNOME components often earlier
than anyone else, it makes sense to test this to ensure that this
continues to work.