### PR TITLE
Add FFmpeg back to Fedora CI

### DIFF
--- a/tests/ci/install-deps-rpm.sh
+++ b/tests/ci/install-deps-rpm.sh
@@ -53,6 +53,7 @@ dnf --assumeyes --quiet --setopt=install_weak_deps=False install \
     xmlto \
     itstool \
     diffutils \
+    /usr/bin/ffmpeg \
     /usr/bin/node \
     /usr/bin/xsltproc \
     /usr/bin/yarnpkg

--- a/tests/ci/install-deps-rpm.sh
+++ b/tests/ci/install-deps-rpm.sh
@@ -5,9 +5,6 @@
 set -e
 set -x
 
-# Install rpmfusion repositories
-dnf --assumeyes --quiet install https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm --eval %fedora).noarch.rpm
-
 # update caches
 dnf makecache
 


### PR DESCRIPTION
Since Fedora Linux 36, there is now an ffmpeg implementation provided in the main repositories, so let's use it.