### PR TITLE
utils: guard mkdir call with std.file.exists

### DIFF
--- a/src/asgen/utils.d
+++ b/src/asgen/utils.d
@@ -252,7 +252,7 @@ void copyDir (in string srcDir, in string destDir, bool useHardlinks = false) @t
         foreach (DirEntry e; dirEntries (deSrc.name, SpanMode.breadth, true)) {
             if (attrIsDir (e.attributes)) {
                 auto childDir = destRoot ~ e.name[srcLen..$];
-                mkdir (childDir);
+                mkdirRecurse (childDir);
             } else {
                 files ~= e.name;
             }


### PR DESCRIPTION
Fixes the following stack trace:

2023-04-23 21:02:16 - INFO: Exporting data for v3.15 (main/aarch64) 2023-04-23 21:02:16std.file.FileException@/usr/include/d/std/file.d(2972): /home/abuild/cache/export/media/v3.15/g/gv/gvim.desktop/4016a69fc2135fa29a3414b2c8bd20d9//icons: File exists ----------------
??:? @trusted bool std.file.cenforce!(bool).cenforce(bool, scope const(char)[], scope const(char)*, immutable(char)[], ulong) [0x563624998170] ??:? @safe void std.file.mkdir!(immutable(char)[]).mkdir(immutable(char)[]) [0x563624a439d0] ??:? @trusted void asgen.utils.copyDir(in immutable(char)[], in immutable(char)[], bool) [0x563624a43500] ??:? /usr/bin/appstream-generator [0x5636249e2190] ??:? void std.parallelism.ParallelForeach!(asgen.backends.interfaces.Package[]).ParallelForeach.opApply(scope int delegate(ref asgen.backends.interfaces.Package)).doIt() [0x5636249e8f30] ??:? void std.parallelism.TaskPool.executeWorkLoop() [0x7fd515e4efe0] ??:? thread_entryPoint [0x7fd515b9d5b0]
 - DEBUG: Building final metadata and hints files.

This occurred once during debugging, but haven't tested this in-depth. Anyway, looking at the code seems sort of obvious fix.