### PR TITLE
Update README.md with new dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,11 @@ Take a look at the [docs/](docs/index.md) directory in the source tree for infor
 
 On Debian and derivatives of it, all build requirements can be installed using the following command:
 ```ShellSession
-sudo apt install meson ldc gir-to-d libappstream-dev libsoup2.4-dev libarchive-dev \
-    libgdk-pixbuf2.0-dev librsvg2-dev libcairo2-dev libfreetype6-dev libfontconfig1-dev \
-    libpango1.0-dev liblmdb-dev libglibd-2.0-dev
+sudo apt install meson ldc gir-to-d \
+    libappstream-dev libappstream-compose-dev libsoup2.4-dev libarchive-dev \
+    libgdk-pixbuf2.0-dev librsvg2-dev libcairo2-dev libfreetype-dev libfontconfig1-dev \
+    libpango1.0-dev liblmdb-dev libglibd-2.0-dev \
+    yarnpkg
 ```
 
 ### Build instructions


### PR DESCRIPTION
libfreetype6-dev is a deprecated (long time ago) transitional package. Use proper one instead.

Add appstream compose header files.

Add yarnpkg, as otherwise default build instructions will not work.