### PR TITLE
Introduce 'localbase' Meson option.

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -17,3 +17,4 @@ option('gir-dir',
        value: '',
        description: 'Override the directory where gir-to-d searches for GIR files.'
 )
+option('localbase', type : 'string', value : '/usr', description : 'Prefix under which all 3rd party software is installed')

--- a/src/asgen/contentsstore.d
+++ b/src/asgen/contentsstore.d
@@ -23,10 +23,12 @@ import std.stdio;
 import std.string;
 import std.conv : to, octal;
 import std.file : mkdirRecurse;
+import std.path : buildPath;
 import std.array : appender, join, split, empty;
 
 import asgen.bindings.lmdb;
 import asgen.config;
+import asgen.defines : LOCALBASE;
 import asgen.logging;
 
 /**
@@ -239,7 +241,9 @@ public:
         auto iconInfo = appender!(string[]);
         auto localeInfo = appender!(string[]);
         foreach (ref f; contents) {
-            if ((f.startsWith("/usr/share/icons/")) ||
+            if ((f.startsWith (buildPath (LOCALBASE, "share/icons/"))) ||
+                (f.startsWith (buildPath (LOCALBASE, "share/pixmaps/"))) ||
+                (f.startsWith ("/usr/share/icons/")) ||
                     (f.startsWith("/usr/share/pixmaps/"))) {
                 iconInfo ~= f;
                 continue;

--- a/src/asgen/datainjectpkg.d
+++ b/src/asgen/datainjectpkg.d
@@ -22,6 +22,7 @@ import std.array : empty;
 import std.path : buildPath, buildNormalizedPath, relativePath, baseName;
 
 import asgen.backends.interfaces;
+import asgen.defines : LOCALBASE;
 import asgen.utils : GENERIC_BUFFER_SIZE, existsAndIsDir;
 import asgen.logging;
 
@@ -142,7 +143,7 @@ public:
         if (iconLocation.existsAndIsDir) {
             foreach (iconFname; iconLocation.dirEntries("*.{svg,svgz,png}", SpanMode.breadth, true)) {
                 immutable iconBasePath = relativePath(iconFname, iconLocation);
-                _contents[buildPath("/usr/share/icons/hicolor", iconBasePath)] = iconFname;
+                _contents[buildPath (LOCALBASE, "share/icons/hicolor", iconBasePath)] = iconFname;
             }
         } else {
             logInfo("No icons found in '%s' for injected metadata.", iconLocation);
@@ -152,7 +153,7 @@ public:
         foreach (miFname; _dataLocation.dirEntries("*.xml", SpanMode.shallow, false)) {
             immutable miBasename = miFname.baseName;
             logDebug("Found injected metainfo [%s]: %s", "all", miBasename);
-            _contents[buildPath("/usr/share/metainfo", miBasename)] = miFname;
+            _contents[buildPath (LOCALBASE, "share/metainfo", miBasename)] = miFname;
         }
 
         if (!archDataLocation.existsAndIsDir)
@@ -161,7 +162,7 @@ public:
         // load arch-specific override metainfo files
         foreach (miFname; archDataLocation.dirEntries("*.xml", SpanMode.shallow, false)) {
             immutable miBasename = miFname.baseName;
-            immutable fakePath = buildPath("/usr/share/metainfo", miBasename);
+            immutable fakePath = buildPath (LOCALBASE, "share/metainfo", miBasename);
 
             if (fakePath in _contents)
                 logDebug ("Found injected metainfo [%s]: %s (replacing generic one)", arch, miBasename);

--- a/src/asgen/defines.d.in
+++ b/src/asgen/defines.d.in
@@ -23,6 +23,9 @@ module asgen.defines;
 // location of arch-indep data for asgen
 public enum DATADIR = "@datadir@";
 
+// prefix into which all 3rd party software is installed
+public enum LOCALBASE = "@localbase@";
+
 // current version of the tool
 public enum ASGEN_VERSION = "@asgen_version@";
 

--- a/src/asgen/engine.d
+++ b/src/asgen/engine.d
@@ -31,6 +31,7 @@ static import std.file;
 import appstream.Component;
 
 import asgen.config;
+import asgen.defines : LOCALBASE;
 import asgen.logging;
 import asgen.extractor;
 import asgen.datastore;
@@ -211,9 +212,9 @@ public:
         {
             auto contents = pkg.contents;
             foreach (ref c; contents) {
-                if (c.startsWith("/usr/share/applications/"))
+                if (c.startsWith (buildPath (LOCALBASE, "share/applications/")))
                     return true;
-                if (c.startsWith("/usr/share/metainfo/"))
+                if (c.startsWith (buildPath (LOCALBASE, "share/metainfo/")))
                     return true;
             }
 

--- a/src/asgen/extractor.d
+++ b/src/asgen/extractor.d
@@ -35,6 +35,7 @@ import glib.Bytes : Bytes;
 import glib.c.types : GPtrArray;
 
 import asgen.config : Config, DataType;
+import asgen.defines : LOCALBASE;
 import asgen.logging;
 import asgen.hintregistry;
 import asgen.result;
@@ -76,7 +77,7 @@ public:
         modInj = modInjInfo;
 
         compose = new Compose;
-        //compose.setPrefix ("/usr");
+        compose.setPrefix (LOCALBASE);
         compose.setMediaResultDir(db.mediaExportPoolDir);
         compose.setMediaBaseurl("");
         compose.setCheckMetadataEarlyFunc(&checkMetadataIntermediate, cast(void*) this);

--- a/src/asgen/iconhandler.d
+++ b/src/asgen/iconhandler.d
@@ -46,6 +46,7 @@ import ascompose.c.types : ImageFormat, ImageLoadFlags, ImageSaveFlags, IconStat
 static import std.file;
 
 import asgen.utils;
+import asgen.defines : LOCALBASE;
 import asgen.logging;
 import asgen.result;
 import asgen.backends.interfaces;
@@ -147,7 +148,7 @@ public:
 
     this (const string name, Package pkg)
     {
-        auto indexData = pkg.getFileData(buildPath("/usr/share/icons", name, "index.theme"));
+        auto indexData = pkg.getFileData (buildPath (LOCALBASE, "share/icons", name, "index.theme"));
         this(name, indexData);
     }
 
@@ -238,10 +239,11 @@ public:
 
             string front () const @property
             {
-                return "/usr/share/icons/%s/%s/%s.%s".format(theme.name,
-                        theme.directories[idxThemeDir]["path"].get!(string),
-                        iname,
-                        extensions[idxExt]);
+                return buildPath (LOCALBASE,
+                         "share/icons/%s/%s/%s.%s".format (theme.name,
+                                                           theme.directories[idxThemeDir]["path"].get!(string),
+                                                           iname,
+                                                           extensions[idxExt]));
             }
 
             void popFront ()
@@ -357,7 +359,7 @@ public:
         foreach (info; parallel(filesPkids.byKeyValue, 100)) {
             immutable fname = info.key;
             immutable pkgid = info.value;
-            if (fname.startsWith("/usr/share/pixmaps/")) {
+            if (fname.startsWith (buildPath (LOCALBASE, "share/pixmaps/"))) {
                 auto pkg = getPackage(pkgid);
                 if (pkg is null)
                     continue;
@@ -368,7 +370,7 @@ public:
 
             // optimization: check if we actually have an interesting path before
             // entering the foreach loop.
-            if (!fname.startsWith("/usr/share/icons/"))
+            if (!fname.startsWith (buildPath (LOCALBASE, "share/icons/")))
                 continue;
 
             auto pkg = getPackage(filesPkids[fname]);
@@ -376,10 +378,10 @@ public:
                 continue;
 
             foreach (name; themeNames) {
-                if (fname == "/usr/share/icons/%s/index.theme".format(name)) {
+                if (fname == buildPath (LOCALBASE, "share/icons/%s/index.theme".format (name))) {
                     synchronized (this)
                         tmpThemes[name] = new Theme(name, pkg);
-                } else if (fname.startsWith("/usr/share/icons/%s".format(name))) {
+                } else if (fname.startsWith (buildPath (LOCALBASE, "share/icons/%s".format (name)))) {
                     synchronized (this)
                         iconFiles[fname] = pkg;
                 }
@@ -477,14 +479,14 @@ public:
                 // this is "wrong", but we support it for compatibility reasons.
                 // However, we only ever use it to satisfy the 64x64px requirement
                 foreach (extension; possibleIconExts)
-                    yield ("/usr/share/icons/%s%s".format(iconName, extension));
+                    yield (buildPath (LOCALBASE, "share/icons/%s%s".format (iconName, extension)));
 
                 // check pixmaps directory for icons
                 // we only ever use the pixmap directory contents to satisfy the minimum 64x64px icon
                 // requirement. Otherwise we get weird upscaling to higher sizes or HiDPI sizes happening,
                 // as later code tries to downscale "bigger" sizes.
                 foreach (extension; possibleIconExts)
-                    yield ("/usr/share/pixmaps/%s%s".format(iconName, extension));
+                    yield (buildPath (LOCALBASE, "share/pixmaps/%s%s".format (iconName, extension)));
             }
         });
 
@@ -1013,9 +1015,9 @@ unittest {
     auto theme = new Theme("hicolor", indexData);
     foreach (fname; theme.matchingIconFilenames("accessories-calculator", ImageSize(48))) {
         bool valid = false;
-        if (fname.startsWith("/usr/share/icons/hicolor/48x48/"))
+        if (fname.startsWith (buildPath (LOCALBASE, "share/icons/hicolor/48x48/")))
             valid = true;
-        if (fname.startsWith("/usr/share/icons/hicolor/scalable/"))
+        if (fname.startsWith (buildPath (LOCALBASE, "share/icons/hicolor/scalable/")))
             valid = true;
         assert(valid);
 
@@ -1031,13 +1033,13 @@ unittest {
     }
 
     foreach (fname; theme.matchingIconFilenames("accessories-text-editor", ImageSize(192))) {
-        if (fname.startsWith("/usr/share/icons/hicolor/192x192/"))
+        if (fname.startsWith (buildPath (LOCALBASE, "share/icons/hicolor/192x192/")))
             continue;
-        if (fname.startsWith("/usr/share/icons/hicolor/256x256/"))
+        if (fname.startsWith (buildPath (LOCALBASE, "share/icons/hicolor/256x256/")))
             continue;
-        if (fname.startsWith("/usr/share/icons/hicolor/512x512/"))
+        if (fname.startsWith (buildPath (LOCALBASE, "share/icons/hicolor/512x512/")))
             continue;
-        if (fname.startsWith("/usr/share/icons/hicolor/scalable/"))
+        if (fname.startsWith (buildPath (LOCALBASE, "share/icons/hicolor/scalable/")))
             continue;
         assert(0);
     }

--- a/src/asgen/meson.build
+++ b/src/asgen/meson.build
@@ -1,6 +1,7 @@
 
 conf_data = configuration_data()
 conf_data.set('datadir', join_paths(get_option('prefix'), get_option('datadir'), 'appstream'))
+conf_data.set('localbase', get_option('localbase'))
 conf_data.set('asgen_version', asgen_version)
 conf_data.set('build_rpmmd', get_option('rpmmd')? 'true' : 'false')
 configure_file(input : 'defines.d.in',


### PR DESCRIPTION
Some Linux distributions as well as FreeBSD OS install 3rd party software into a prefix that differs from "/usr". This change makes asgen work in such cases.