### PR TITLE
snap: Don't include our glib (#131)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -213,6 +213,17 @@ parts:
       - locales-all
       - optipng
       - shared-mime-info
+    prime:
+      - -usr/lib/*/libglib-*
+      - -usr/lib/*/libgio*
+      - -usr/lib/*/libgmodule*
+      - -usr/lib/*/libgobject*
+      - -usr/lib/*/libgthread*
+      - -usr/lib/*/pkgconfig/gio*
+      - -usr/lib/*/pkgconfig/glib-2.0.pc
+      - -usr/lib/*/pkgconfig/gmodule*
+      - -usr/lib/*/pkgconfig/gobject-2.0.pc
+      - -usr/lib/*/pkgconfig/gthread-2.0.pc
     after:
       - appstream
       - gir-to-d


### PR DESCRIPTION
We should use the one shipped by the gnome snap; us including ours results in breakages such as symbol lookup errors due to mismatched glib versions.

/cc @kenvandine for review