### PR TITLE
Add AdwaitaLegacy to themeNames

### DIFF
--- a/src/asgen/iconhandler.d
+++ b/src/asgen/iconhandler.d
@@ -340,6 +340,7 @@ public:
         if (iconTheme !is null)
             themeNames ~= iconTheme;
         themeNames ~= "Adwaita"; // GNOME
+        themeNames ~= "AdwaitaLegacy"; // GNOME
         themeNames ~= "breeze"; // KDE
 
         Package getPackage (const string pkid)


### PR DESCRIPTION
Most of the non-symbolic icons were moved from Adwaita to AdwaitaLegacy, but some legacy applications still use them.

References:
- https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/issues/288
- https://gitlab.gnome.org/GNOME/adwaita-icon-theme-legacy