### PR TITLE
Add and enforce an npm lockfile

### DIFF
--- a/contrib/setup/build_js.sh
+++ b/contrib/setup/build_js.sh
@@ -11,7 +11,7 @@ then
     NPM=$1
 fi
 
-$NPM install --no-save
+$NPM ci --ignore-scripts
 
 JS_TARGET=../../data/templates/default/static/js
 [ ! -d "$JS_TARGET" ] && mkdir $JS_TARGET

--- a/contrib/setup/package-lock.json
+++ b/contrib/setup/package-lock.json
@@ -1,0 +1,33 @@
+{
+  "name": "setup",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "highlightjs": "^9.10.0",
+        "jquery": "^3.3.1",
+        "jquery-flot": "^0.8.3"
+      }
+    },
+    "node_modules/highlightjs": {
+      "version": "9.16.2",
+      "resolved": "https://registry.npmjs.org/highlightjs/-/highlightjs-9.16.2.tgz",
+      "integrity": "sha512-FK1vmMj8BbEipEy8DLIvp71t5UsC7n2D6En/UfM/91PCwmOpj6f2iu0Y0coRC62KSRHHC+dquM2xMULV/X7NFg==",
+      "deprecated": "Use the 'highlight.js' package instead https://npm.im/highlight.js",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "license": "MIT"
+    },
+    "node_modules/jquery-flot": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/jquery-flot/-/jquery-flot-0.8.3.tgz",
+      "integrity": "sha512-IkQCsA5t55Aubu8iove/X/KL34rdZTsDyx/bylC7F320N2bwsJhJe3Np8orsx1L8FEOoMDfNe3/pSb3xXKLxeQ==",
+      "deprecated": "flot has been abandoned"
+    }
+  }
+}


### PR DESCRIPTION
Previously a yarn lockfile was present, but removed together with the migration to npm (https://github.com/selfisekai/appstream-generator/commit/661f2c84cd134301d66a67eba24480222b9277cb)