### PR TITLE
FreeBSD backend: Implement packageForFile()

### DIFF
--- a/src/backends/freebsd/fbsdpkg.h
+++ b/src/backends/freebsd/fbsdpkg.h
@@ -39,7 +39,9 @@ class ArchiveDecompressor;
 class FreeBSDPackage : public Package
 {
 public:
-    FreeBSDPackage(const std::string &pkgRoot, const nlohmann::json &j);
+    static FreeBSDPackage* CreateFromWorkdir(const std::string &workDir);
+
+    FreeBSDPackage(const std::string &repoRoot, const nlohmann::json &j);
     ~FreeBSDPackage() override = default;
 
     std::string name() const override;
@@ -60,11 +62,15 @@ public:
     PackageKind kind() const noexcept override;
 
 private:
-    nlohmann::json m_pkgjson;
+    FreeBSDPackage();
+
+    nlohmann::json m_pkgJson;
     fs::path m_pkgFname;
     PackageKind m_kind;
     std::unique_ptr<ArchiveDecompressor> m_pkgArchive;
     std::vector<std::string> m_contentsL;
+    bool m_isWorkdirPackage = false;
+    fs::path m_stageDir;
 
     // Mutable cache members for lazy initialization of summary/description
     mutable std::unordered_map<std::string, std::string> m_summaryCache;

--- a/src/backends/freebsd/fbsdpkgindex.cpp
+++ b/src/backends/freebsd/fbsdpkgindex.cpp
@@ -60,8 +60,8 @@ std::vector<std::shared_ptr<Package>> FreeBSDPackageIndex::loadPackages(
     const std::string &section,
     const std::string &arch)
 {
-    const auto pkgRoot = m_rootDir / suite;
-    const auto metaFname = pkgRoot / "meta.conf";
+    const auto repoRoot = m_rootDir / suite;
+    const auto metaFname = repoRoot / "meta.conf";
     std::string dataFname;
 
     if (!fs::exists(metaFname)) {
@@ -83,7 +83,7 @@ std::vector<std::shared_ptr<Package>> FreeBSDPackageIndex::loadPackages(
         }
     }
 
-    const auto dataTarFname = pkgRoot / (dataFname + ".pkg");
+    const auto dataTarFname = repoRoot / (dataFname + ".pkg");
     if (!fs::exists(dataTarFname)) {
         logError("Package lists file '{}' does not exist.", dataTarFname.string());
         return {};
@@ -114,7 +114,7 @@ std::vector<std::shared_ptr<Package>> FreeBSDPackageIndex::loadPackages(
     if (dataJson.contains("packages") && dataJson["packages"].is_array()) {
         for (const auto &entry : dataJson["packages"]) {
             if (entry.is_object()) {
-                auto pkg = std::make_shared<FreeBSDPackage>(pkgRoot.string(), entry);
+                auto pkg = std::make_shared<FreeBSDPackage>(repoRoot.string(), entry);
                 packages.push_back(std::static_pointer_cast<Package>(pkg));
             }
         }
@@ -149,7 +149,11 @@ std::shared_ptr<Package> FreeBSDPackageIndex::packageForFile(
     const std::string &suite,
     const std::string &section)
 {
-    // Not implemented for FreeBSD backend
+    if (!fs::exists(fname) || !fs::is_directory(fname)) {
+        logError("Path '{}' does not exist or is not a directory", fname);
+        return nullptr;
+    }
+
     return nullptr;
 }
 


### PR DESCRIPTION
As it turned out in https://github.com/ximion/appstream-generator/issues/111 running `appstream-generator` on an already built repository is too time consuming - it requires unpacking each package to scan its contents, which might be very slow for some packages.

This change allows for a different workflow. During the package building, the `appstream-generator process-file` is called for each package, right before the archive creating step. This command actually gets feed not a file, but a directory that represent the to-be-created package contents. This allows asgen to process the data blazing fast.

At the end of the package building, I run `appstream-generator publish` to actually create the AppStream metadata files.