### PR TITLE
zarchive: Ensure parent directories are created for empty directories

### DIFF
--- a/src/zarchive.cpp
+++ b/src/zarchive.cpp
@@ -359,7 +359,7 @@ void ArchiveDecompressor::extractArchive(const std::string &dest)
         auto filetype = archive_entry_filetype(en);
         if (filetype == AE_IFDIR) {
             if (!fs::exists(pathname))
-                fs::create_directory(pathname);
+                fs::create_directories(pathname);
             continue;
         }
 


### PR DESCRIPTION
Previously, when in the optimized reads path, it could fail to properly extract archives which contained empty directories. Use `fs::create_directories` instead of `fs::create_directory` to ensure parent directories of empty directories are created.

Context:
We recently enabled optimized reads support for large archives in the solus backend, however, we encountered issues if the archive took the optimized read path and contained empty last level directories. Removing the empty directories from affected packages worked around the issue.

e.g.
```
2026-07-05 09:02:05 - ERROR: Failed to read data from package unit: filesystem error: cannot create directory: No such file or directory [/home/ninya/solus/appstream-generator/workspace/cache/tmp/asgen-NucMjizr/eopkg-brave-1.92.134-279/data/usr/share/doc/brave-browser-stable/]
2026-07-05 09:02:05 - ERROR: Failed to create symlink '/home/ninya/solus/appstream-generator/workspace/cache/tmp/asgen-NucMjizr/eopkg-brave-1.92.134-279/data/usr/bin/brave-browser-stable' -> '../share/brave/brave': filesystem error: cannot create symlink: File exists [../share/brave/brave] [/home/ninya/solus/appstream-generator/workspace/cache/tmp/asgen-NucMjizr/eopkg-brave-1.92.134-279/data/usr/bin/brave-browser-stable]
2026-07-05 09:02:10 - ERROR: Failed to read data from package unit: filesystem error: cannot create directory: No such file or directory [/home/ninya/solus/appstream-generator/workspace/cache/tmp/asgen-NucMjizr/eopkg-brave-1.92.134-279/data/usr/share/doc/brave-browser-stable/]
2026-07-05 09:02:10 - ERROR: Failed to create symlink '/home/ninya/solus/appstream-generator/workspace/cache/tmp/asgen-NucMjizr/eopkg-brave-1.92.134-279/data/usr/bin/brave-browser-stable' -> '../share/brave/brave': filesystem error: cannot create symlink: File exists [../share/brave/brave] [/home/ninya/solus/appstream-generator/workspace/cache/tmp/asgen-NucMjizr/eopkg-brave-1.92.134-279/data/usr/bin/brave-browser-stable]
2026-07-05 09:02:14 - ERROR: Failed to read data from package unit: filesystem error: cannot create directory: No such file or directory [/home/ninya/solus/appstream-generator/workspace/cache/tmp/asgen-NucMjizr/eopkg-brave-1.92.134-279/data/usr/share/doc/brave-browser-stable/]
```

Where `usr/share/doc/brave-browser-stable/` was an empty directory causing `usr/share/` to be not be created.